### PR TITLE
Prep for 0.2.3 release - ParmEd version requirement, rdkit removal, version # incr.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ script:
   # Install package prerequisites
   - conda install --yes --quiet pip nose nose-timer
   - conda install --yes --quiet packmol
+  - conda install --yes --quiet rdkit
   - pip install $OPENEYE_CHANNEL openeye-toolkits
   # Test the package
   - cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=2 --with-doctest --with-timer -a '!slow' && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ script:
   # Install package prerequisites
   - conda install --yes --quiet pip nose nose-timer
   - conda install --yes --quiet packmol
-  - conda install --yes --quiet rdkit
   - pip install $OPENEYE_CHANNEL openeye-toolkits
   # Test the package
   - cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=2 --with-doctest --with-timer -a '!slow' && cd ..

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - scipy
     - ambermini
     - parmed-dev
-    - rdkit
     - openmoltools
     - mdtraj
     - packmol
@@ -35,7 +34,6 @@ requirements:
     - ambermini
     - parmed-dev
     - libgfortran ==1.0 # [linux]
-    - rdkit
     - openmoltools
     - mdtraj 
     - packmol

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - scipy
     - ambermini
     - parmed-dev
+    - rdkit
     - openmoltools
     - mdtraj
     - packmol
@@ -33,6 +34,7 @@ requirements:
     - scipy
     - ambermini
     - parmed-dev
+    - rdkit
     - libgfortran ==1.0 # [linux]
     - openmoltools
     - mdtraj 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ if sys.version_info[:2] < (2, 7):
 
 
 ##########################
-VERSION = "0.2.2.dev0"
-ISRELEASED = False
+VERSION = "0.2.3"
+ISRELEASED = True
 __version__ = VERSION
 ##########################
 

--- a/solvationtoolkit/solvated_mixtures.py
+++ b/solvationtoolkit/solvated_mixtures.py
@@ -31,7 +31,7 @@ import openmoltools
 import solvationtoolkit.mol2tosdf as mol2tosdf
 
 
-# We require at least ParmEd 2.5.1 because of issues with the .mol2 writer (issue #691 on ParmEd) prior to that.
+# We require at least ParmEd 2.5.1 because of issues with the .mol2 writer (issue #691 on ParmEd) prior to that, and 2.5.1.10 because of OpenEye reader formatting bugs requireing compressed spacing in .mol2 files (added in ParmEd 2.5.1.10)
 # Previously 2.0.4 or later was required due to issues with FudgeLJ/FudgeQQ in resulting GROMACS topologies in
 #  earlier versions
 try: #Try to get version tag
@@ -39,7 +39,7 @@ try: #Try to get version tag
 except: #If too old for version tag, it is too old
     oldParmEd = Exception('ERROR: ParmEd is too old, please upgrade to 2.5.1 or later')
     raise oldParmEd
-if ver < (2,5,1):
+if ver < (2,5,1,10):
     raise RuntimeError("ParmEd is too old, please upgrade to 2.5.1 or later")
 
 


### PR DESCRIPTION
Preps for 0.2.3 release by incrementing version number and IsReleased status; removing unnecessary `rdkit` from conda recipe, and correcting the `ParmEd` version requirement.