### PR TITLE
Finish API changes begun in #61

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if sys.version_info[:2] < (2, 7):
 
 
 ##########################
-VERSION = "0.2.4.dev0"
+VERSION = "0.4.0.dev0"
 ISRELEASED = False
 __version__ = VERSION
 ##########################


### PR DESCRIPTION
This should finish the API changes begun in #61 and also resolve #63 ; it involves a complete rewrite of the tests (relative to #61) and a lot of other bugfixes/clarifications/etc to #61.

- Updated version string debugging info in solvated_mixtures.py
- Length updates to doc string and comments
- Doc string updates for MixtureSystem
- Error message clarifications
- Updates to ensure failures to generate SMILES are caught
- Update version string to 0.3.0.dev0
- Switch every instance of "smile" as in "smile string" to "smiles" as is proper.
- Replace the "numbers" of each component with the "number" of each component since each component has ONE number of monomers
- Move creation of GROMACS and AMBER file names into the build function, as these are not known on construction
- Move initialization of lists of components (smiles, number of molecules, etc) into the build section as these are not final until we build
- Fix function of "solute_index"
- Tests changes:
    - REQUIRE OpenEye for testing and usage now that it is working on Travis
    - Totally rewrite all tests