### PR TITLE
Push to anaconda.org automatically from travis-ci after build success (for testing)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os: 
+    - linux
+    - osx
+
 language: c
 sudo: false
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ env:
 
 after_success:
   - echo "after_success"
-  #- source devtools/travis-ci/after_success.sh
+  - source devtools/travis-ci/after_success.sh
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os: 
     - linux
-    - osx
+    #- osx
 
 language: c
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,8 @@ env:
     - PACKAGENAME="solvationtoolkit"
     # Location of decrypted OpenEye license file
     - OE_LICENSE="$HOME/oe_license.txt"
-    # encrypted BINSTAR_TOKEN for push of dev package to binstar
-    - secure: "S9I5imZ0CJdwfhHzy+Beh8NTFm2ZYpMFCLgvBYT/UsifIKlGynUK2xGi7bDnHLpslT45FUMmjzdpf2QNrfbivVJgiSDTQJc1GCIqGFFKFqerJEEYUkXlBxvWNO+poSOMIzkJqd7xsTodt4CYhGJM1dT6ocaSM7UJgAErrcRJfLo="
+    # encrypted ANACONDA_TOKEN for push of dev package to Anaconda
+    - secure: "QflOtg3nSmlKJlXCR+CEYnHSRfLemF7vTDjWK0H3dPe8mu+9eEbIiJyIupZI+Zg0fgcgqnqb9k9IZNKCi5K7gKmNemnNuKEDxxzxAkTf3abaoTJ2YaUx2yFO1SKrkfeqaH8x4jxehnM/H7QDaC7cjcQEVqgc2uKNWzchEcz5/ywqhj7HOxwhEo9cT93f713jZwlK3BZzo8E7HVPh9Docs920FxgIXQ5e6d6wAg8f84zb9DLK3WcVJfj8PFuIjPJqFcEw1tCTpcVmWlu6Rf01mcPuygHMzk5GzxSkIhOIz+IXbg2XuxntH4G2geGVwDyw4sX+5NDjIktuDo9j+G1WTvkbWl4TiJNeA2CGuga/247k6qYCSEQCI6lHs6zNaM1gaD1CNtrY2f9ciwinZP748Dsrq5uqdyCNlZusdk9bpw2vx//46AS+cugMz8wYd2S/LBxSjpgD7e01DvZtfaWWc6AphvUWM+SXyzIOP6pXHxfkBNj4y0Kbo1n2uO1TrFHl/6FSJ6uUeSWcyXZRZHbAJNo35juU55gOTOoIOzOOwUWk/gKz4S4hAm5PVLcQ9vHsinACCHPTTNCOar5qNLzacfCnTowxyNJ31McayMZfrougqsFbhVAwGXIJaxFPqrTSPPhx+kEtJGxM2pyYATp/eXwLm/RNG1zHZsuoXfBGVZ8=" 
 
 after_success:
   - echo "after_success"

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
-  name: solvationtoolkiti-dev
-  version: 0.2.2.dev0
+  name: solvationtoolkit-dev
+  version: 0.4.0.dev0
 
 source:
   path: ../../

--- a/devtools/travis-ci/after_success.sh
+++ b/devtools/travis-ci/after_success.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Must be invoked with $PACKAGENAME
+
+echo $TRAVIS_PULL_REQUEST $TRAVIS_BRANCH
+
+if [ "$TRAVIS_PULL_REQUEST" = true ]; then
+    echo "This is a pull request. No deployment will be done."; exit 0
+fi
+
+
+if [ "$TRAVIS_BRANCH" != "master" ]; then
+    echo "No deployment on BRANCH='$TRAVIS_BRANCH'"; exit 0
+fi
+
+
+# Deploy to anaconda
+conda install --yes anaconda-client jinja2 
+pushd .
+cd $HOME/miniconda/conda-bld
+FILES=*/${PACKAGENAME}-dev-*.tar.bz2
+for filename in $FILES; do
+    #We're aiming to get this into omnia eventually but for now, dmobley channel
+    anaconda -t $ANACONDA_TOKEN remove --force dmobley/${PACKAGENAME}-dev/${filename}
+    anaconda -t $ANACONDA_TOKEN upload --force -u dmobley -p ${PACKAGENAME}-dev ${filename}
+    #anaconda -t $ANACONDA_TOKEN remove --force ${ORGNAME}/${PACKAGENAME}-dev/${filename}
+    #anaconda -t $ANACONDA_TOKEN upload --force -u ${ORGNAME} -p ${PACKAGENAME}-dev ${filename}
+done
+popd
+


### PR DESCRIPTION
Adding `after_success.sh` script after build success to push successful builds to anaconda.org (under `dmobley` channel for now) under the -dev label. Various other related/enabling changes to yaml and .sh files to enable this. 