### PR TITLE
Update for 0.4.3 release

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: solvationtoolkit
-  version: 0.4.2
+  version: 0.4.3
 
 source:
   path: ../../

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if sys.version_info[:2] < (2, 7):
 
 
 ##########################
-VERSION = "0.4.3.dev0"
+VERSION = "0.4.3"
 ISRELEASED = False
 __version__ = VERSION
 ##########################


### PR DESCRIPTION
Tweak setup.py for 0.4.3 release; need new point release to roll out conda version which is not dependent on `ligbfortran`.